### PR TITLE
feat: implement uninstall functionality

### DIFF
--- a/README-fa.md
+++ b/README-fa.md
@@ -242,6 +242,34 @@ bash <(curl -Ls https://raw.githubusercontent.com/bugfloyd/dnstt-deploy/main/dns
 # اسکریپت به طور خودکار بروزرسانی‌ها را تشخیص داده و نصب خواهد کرد
 ```
 
+### حذف نصب
+
+برای حذف کامل سرور dnstt و تمام اجزای آن:
+
+```bash
+bash <(curl -Ls https://raw.githubusercontent.com/bugfloyd/dnstt-deploy/main/dnstt-deploy.sh) uninstall
+```
+
+یا اگر اسکریپت نصب شده است:
+
+```bash
+dnstt-deploy uninstall
+```
+
+فرآیند حذف نصب موارد زیر را انجام خواهد داد:
+- توقف و غیرفعال کردن تمام سرویس‌ها (dnstt-server و danted)
+- حذف فایل‌های سرویس systemd
+- حذف باینری dnstt-server
+- حذف فایل‌ها و دایرکتوری پیکربندی (`/etc/dnstt`)
+- حذف قوانین iptables
+- حذف قوانین firewall (firewalld/ufw)
+- حذف کاربر سیستم `dnstt`
+- حذف اختیاری اسکریپت `dnstt-deploy` (با تأیید)
+
+**توجه**: اگر Dante (dante-server) را از طریق package manager نصب کرده‌اید، ممکن است بخواهید آن را به صورت دستی حذف کنید:
+- **RHEL-based** (dnf/yum): `sudo dnf remove dante-server` یا `sudo yum remove dante-server`
+- **Debian-based** (apt): `sudo apt remove dante-server`
+
 ## عیب‌یابی
 
 ### استفاده از ابزارهای داخلی

--- a/README.md
+++ b/README.md
@@ -241,6 +241,34 @@ bash <(curl -Ls https://raw.githubusercontent.com/bugfloyd/dnstt-deploy/main/dns
 # The script will detect and install updates automatically
 ```
 
+### Uninstalling
+
+To completely remove dnstt server and all its components:
+
+```bash
+bash <(curl -Ls https://raw.githubusercontent.com/bugfloyd/dnstt-deploy/main/dnstt-deploy.sh) uninstall
+```
+
+Or if the script is installed:
+
+```bash
+dnstt-deploy uninstall
+```
+
+The uninstall process will:
+- Stop and disable all services (dnstt-server and danted)
+- Remove systemd service files
+- Remove the dnstt-server binary
+- Remove configuration files and directory (`/etc/dnstt`)
+- Remove iptables rules
+- Remove firewall rules (firewalld/ufw)
+- Remove the `dnstt` system user
+- Optionally remove the `dnstt-deploy` script itself (with confirmation)
+
+**Note**: If you installed Dante (dante-server) via package manager, you may want to remove it manually:
+- **RHEL-based** (dnf/yum): `sudo dnf remove dante-server` or `sudo yum remove dante-server`
+- **Debian-based** (apt): `sudo apt remove dante-server`
+
 ## Troubleshooting
 
 ### Using the Built-in Tools


### PR DESCRIPTION
This PR adds a comprehensive uninstall functionality to the dnstt-deploy script, allowing users to completely remove all dnstt components from their system.

### Usage

Users can now uninstall dnstt by running:

```bash
bash <(curl -Ls https://raw.githubusercontent.com/bugfloyd/dnstt-deploy/main/dnstt-deploy.sh) uninstall
```